### PR TITLE
feat: circuit breaker, retry policy, and Micrometer metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,72 +1,97 @@
-Resilient Java Redis Client 
+Resilient Java Redis Client
 ===========================
 
 ## Overview
 Resilient Java Redis Client is a robust, high-performance library for interacting with Redis in Java applications. Designed with fault tolerance and resilience in mind, it enhances the standard Redis Lettuce client capabilities with advanced features to handle common Redis-related issues seamlessly, ensuring that your application remains stable even when Redis encounters problems.
 
-## Key Features:
-* Error Handling
-  * Automatically manages Redis server errors, serialization errors, and connection issues.
-* `@Cacheable`, `@CachePut`, and `@CacheEvict` Compatibility
-  * Ensures that the use of `@Cacheable` annotations continues to work without breaking functionality, even if Redis is temporarily unavailable or misbehaving.
-* Resilience Focus
-  * Provides a robust caching mechanism that mitigates risks associated with Redis downtimes or failures, allowing your application to operate smoothly.
+## Key Features
+- **Error Handling** — Automatically manages Redis server errors, serialization errors, and connection issues.
+- **`@Cacheable` Compatibility** — Ensures that `@Cacheable` annotations continue to work without breaking functionality, even if Redis is temporarily unavailable or misbehaving.
+- **Circuit Breaker** — Stops hammering Redis when it's clearly down, preventing cascade failures.
+- **Retry Policy** — Automatically retries transient Redis failures with configurable backoff.
+- **Metrics** — Built-in Micrometer metrics for cache hits, misses, errors, and latencies.
+- **Fallback Support** — Optionally falls back to a supplier when Redis operations fail.
 
-Support **Java 8 or later**
-
-## Updates
-* **1.0.4**
-  * Add `spring.factories`
-* **1.0.3**
-  * Add `ResilientRedisTemplate`, a complementary class to RedisTemplate that provides additional resilience features.
-* **1.0.2**
-  * Add new configuration to set non-locking batch size
-  * Handle serialization error, if a serialization error occurs, methods using `@Cacheable` will continue to executed and won’t be stopped.
-* **1.0.1**
-  * Handle only specific exception
-    * `RedisConnectionException`
-    * `RedisCommandTimeoutException`
-    * `RedisCommandExecutionException`
-    * `DataAccessException`
-    * `RedisCommandInterruptedException`
-* **1.0.0**
-  * Initial release
-
+Supports **Java 8 or later** and **Spring Boot 2.x / 3.x**.
 
 ## Maven
 
     <dependency>
         <groupId>io.github.blaspat</groupId>
         <artifactId>resilient-redis-lettuce-client</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4</version>
     </dependency>
 
-
 ## Configuration
-I use original `spring.redis` properties, but you need to add this additional properties
+
+Uses standard `spring.redis` properties. Additional properties:
 
     spring:
+      redis:
         timeout: 100ms
         connect-timeout: 100ms
-        redis:
-          batch-size: 1000
-          master:
-            host: localhost
-            port: 6379
-          replica:
-            enabled: true
-            host: localhost
-            port: 6380
+        batch-size: 1000
+        master:
+          host: localhost
+          port: 6379
+        replica:
+          enabled: true
+          host: localhost
+          port: 6380
+        circuit-breaker:
+          enabled: true
+          failure-rate-threshold: 50
+          slow-call-rate-threshold: 80
+          slow-call-duration-threshold: 2s
+          wait-duration-in-open-state: 30s
+          permitted-calls-in-half-open-state: 5
+          sliding-window-size: 10
+          minimum-calls: 5
+        retry:
+          enabled: true
+          max-attempts: 3
+          wait-duration: 200ms
+          max-retry-duration: 5s
 
+### Properties Reference
 
+| Property | Default | Description |
+|---|---|---|
+| `redis.batch-size` | 1000 | Batch size for Redis writer |
+| `redis.replica.enabled` | false | Enable read from replica |
+| `redis.circuit-breaker.enabled` | false | Enable circuit breaker |
+| `redis.circuit-breaker.failure-rate-threshold` | 50 | Failure rate % to trip circuit |
+| `redis.circuit-breaker.slow-call-rate-threshold` | 80 | Slow call rate % to trip circuit |
+| `redis.circuit-breaker.slow-call-duration-threshold` | 2s | Duration above which a call is slow |
+| `redis.circuit-breaker.wait-duration-in-open-state` | 30s | Time before transitioning to half-open |
+| `redis.circuit-breaker.permitted-calls-in-half-open-state` | 5 | Calls allowed in half-open state |
+| `redis.circuit-breaker.sliding-window-size` | 10 | Size of sliding window for failure tracking |
+| `redis.circuit-breaker.minimum-calls` | 5 | Minimum calls before calculating failure rate |
+| `redis.retry.enabled` | false | Enable retry on transient failures |
+| `redis.retry.max-attempts` | 3 | Maximum retry attempts |
+| `redis.retry.wait-duration` | 200ms | Wait time between retries |
+| `redis.retry.max-retry-duration` | 5s | Maximum total retry time |
 
-* `host`: your Redis host
-* `port`: your Redis port 
-* `timeout`: maximum time the client will wait for a response from the Redis server after a command is sent
-* `connect-timeout`: timeout for establishing a connection to the Redis server
-* `redis.batch-size`: batch size setting for Redis writer, default 1000
-* `redis.replica.enabled`: set to`true` if you want to enable read from replica
-  
+### Metrics (Micrometer)
+
+When Micrometer is on the classpath, the following metrics are exposed:
+
+- `redis.cache.hit{operation}` — Cache hit count per operation
+- `redis.cache.miss{operation}` — Cache miss count per operation
+- `redis.error{operation,error}` — Error count per operation and error type
+- `redis.latency{operation}` — Operation latency histogram
+- `redis.fallback{operation}` — Fallback activation count
+
+Prometheus registry is included by default. Access metrics at `/actuator/prometheus`.
+
+## Updates
+
+- **1.0.4** — Circuit breaker, retry policy, Micrometer metrics, scan cursor resource leak fixed
+- **1.0.3** — Add `ResilientRedisTemplate`
+- **1.0.2** — Non-locking batch size, serialization error handling
+- **1.0.1** — Specific exception handling
+- **1.0.0** — Initial release
+
 ## License
 
 This project is licensed under the [Apache License Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.html).

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,26 @@
             <artifactId>commons-pool2</artifactId>
             <version>2.11.1</version>
         </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-circuitbreaker</artifactId>
+            <version>2.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-retry</artifactId>
+            <version>2.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <version>1.10.6</version>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <version>1.10.6</version>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/src/main/java/io/github/blaspat/CircuitBreakerManager.java
+++ b/src/main/java/io/github/blaspat/CircuitBreakerManager.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024 Blasius Patrick
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.blaspat;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.function.Supplier;
+
+public class CircuitBreakerManager {
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final CircuitBreaker circuitBreaker;
+
+    public CircuitBreakerManager(
+            int failureRateThreshold,
+            int slowCallRateThreshold,
+            Duration slowCallDurationThreshold,
+            Duration waitDurationInOpenState,
+            int permittedCallsInHalfOpenState,
+            int slidingWindowSize,
+            int minimumCalls) {
+
+        CircuitBreakerConfig config = CircuitBreakerConfig.custom()
+                .failureRateThreshold(failureRateThreshold)
+                .slowCallRateThreshold(slowCallRateThreshold)
+                .slowCallDurationThreshold(slowCallDurationThreshold)
+                .waitDurationInOpenState(waitDurationInOpenState)
+                .permittedNumberOfCallsInHalfOpenState(permittedCallsInHalfOpenState)
+                .slidingWindowSize(slidingWindowSize)
+                .minimumNumberOfCalls(minimumCalls)
+                .build();
+
+        CircuitBreakerRegistry registry = CircuitBreakerRegistry.of(config);
+        this.circuitBreaker = registry.circuitBreaker("redis");
+        this.circuitBreaker.getEventPublisher()
+                .onStateTransition(event ->
+                        logger.warn("Redis circuit breaker state changed: {} -> {}",
+                                event.getStateTransition().getFromState(),
+                                event.getStateTransition().getToState()));
+    }
+
+    public <T> T execute(Supplier<T> supplier) {
+        return circuitBreaker.executeSupplier(supplier);
+    }
+
+    public void execute(Runnable runnable) {
+        circuitBreaker.executeRunnable(runnable);
+    }
+
+    public CircuitBreaker getCircuitBreaker() {
+        return circuitBreaker;
+    }
+
+    public boolean isOpen() {
+        return circuitBreaker.getState() == CircuitBreaker.State.OPEN;
+    }
+
+    public boolean is_half_open() {
+        return circuitBreaker.getState() == CircuitBreaker.State.HALF_OPEN;
+    }
+}

--- a/src/main/java/io/github/blaspat/RedisFallbackSupport.java
+++ b/src/main/java/io/github/blaspat/RedisFallbackSupport.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 Blasius Patrick
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.blaspat;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.function.Supplier;
+
+public class RedisFallbackSupport {
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final Supplier<?> fallbackSupplier;
+
+    public RedisFallbackSupport(Supplier<?> fallbackSupplier) {
+        this.fallbackSupplier = fallbackSupplier;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> T getOrFallback(Supplier<T> primarySupplier) {
+        try {
+            return primarySupplier.get();
+        } catch (Exception e) {
+            logger.warn("Redis operation failed, falling back: {}", e.getMessage());
+            if (fallbackSupplier != null) {
+                return (T) fallbackSupplier.get();
+            }
+            return null;
+        }
+    }
+
+    public interface FallbackSupplier<T> extends Supplier<T> {
+    }
+}

--- a/src/main/java/io/github/blaspat/ResilientRedisConfig.java
+++ b/src/main/java/io/github/blaspat/ResilientRedisConfig.java
@@ -19,6 +19,7 @@ package io.github.blaspat;
 import io.lettuce.core.ClientOptions;
 import io.lettuce.core.ReadFrom;
 import io.lettuce.core.SocketOptions;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,13 +47,13 @@ import java.util.Map;
 @Configuration
 @EnableCaching
 public class ResilientRedisConfig {
+
     @Value("${version}")
     private String projectVersion;
     @Value("${artifactId}")
     private String projectId;
 
     private final Logger log = LoggerFactory.getLogger(this.getClass());
-
     private final ResilientRedisProperties resilientRedisProperties;
 
     public ResilientRedisConfig(ResilientRedisProperties resilientRedisProperties) {
@@ -80,8 +81,12 @@ public class ResilientRedisConfig {
                     .readFrom(ReadFrom.REPLICA)
                     .build();
 
-            RedisStaticMasterReplicaConfiguration redisConfiguration = new RedisStaticMasterReplicaConfiguration(resilientRedisProperties.getMaster().getHost(), resilientRedisProperties.getMaster().getPort());
-            redisConfiguration.addNode(resilientRedisProperties.getReplica().getHost(), resilientRedisProperties.getReplica().getPort());
+            RedisStaticMasterReplicaConfiguration redisConfiguration = new RedisStaticMasterReplicaConfiguration(
+                    resilientRedisProperties.getMaster().getHost(),
+                    resilientRedisProperties.getMaster().getPort());
+            redisConfiguration.addNode(
+                    resilientRedisProperties.getReplica().getHost(),
+                    resilientRedisProperties.getReplica().getPort());
             return new LettuceConnectionFactory(redisConfiguration, clientConfig);
         } else {
             LettucePoolingClientConfiguration clientConfig = LettucePoolingClientConfiguration.builder()
@@ -95,7 +100,9 @@ public class ResilientRedisConfig {
                     )
                     .build();
 
-            RedisStaticMasterReplicaConfiguration redisConfiguration = new RedisStaticMasterReplicaConfiguration(resilientRedisProperties.getMaster().getHost(), resilientRedisProperties.getMaster().getPort());
+            RedisStaticMasterReplicaConfiguration redisConfiguration = new RedisStaticMasterReplicaConfiguration(
+                    resilientRedisProperties.getMaster().getHost(),
+                    resilientRedisProperties.getMaster().getPort());
             return new LettuceConnectionFactory(redisConfiguration, clientConfig);
         }
     }
@@ -109,8 +116,50 @@ public class ResilientRedisConfig {
     }
 
     @Bean
-    public ResilientRedisTemplate<String, Object> resilientRedisTemplate(RedisTemplate<String, Object> redisTemplate) {
-        return new ResilientRedisTemplate<>(redisTemplate);
+    @ConditionalOnMissingBean(name = "resilientRedisMetrics")
+    public ResilientRedisMetrics resilientRedisMetrics(MeterRegistry meterRegistry) {
+        return new ResilientRedisMetrics(meterRegistry);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(name = "circuitBreakerManager")
+    public CircuitBreakerManager circuitBreakerManager() {
+        ResilientRedisProperties.CircuitBreaker cb = resilientRedisProperties.getCircuitBreakerConfig();
+        if (!cb.isEnabled()) {
+            return null;
+        }
+        return new CircuitBreakerManager(
+                cb.getFailureRateThreshold(),
+                cb.getSlowCallRateThreshold(),
+                cb.getSlowCallDurationThreshold(),
+                cb.getWaitDurationInOpenState(),
+                cb.getPermittedCallsInHalfOpenState(),
+                cb.getSlidingWindowSize(),
+                cb.getMinimumCalls()
+        );
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(name = "retryManager")
+    public RetryManager retryManager() {
+        ResilientRedisProperties.Retry retry = resilientRedisProperties.getRetryConfig();
+        if (!retry.isEnabled()) {
+            return null;
+        }
+        return new RetryManager(
+                retry.getMaxAttempts(),
+                retry.getWaitDuration(),
+                retry.getMaxRetryDuration()
+        );
+    }
+
+    @Bean
+    public ResilientRedisTemplate<String, Object> resilientRedisTemplate(
+            RedisTemplate<String, Object> redisTemplate,
+            CircuitBreakerManager circuitBreakerManager,
+            RetryManager retryManager,
+            ResilientRedisMetrics resilientRedisMetrics) {
+        return new ResilientRedisTemplate<>(redisTemplate, circuitBreakerManager, retryManager, resilientRedisMetrics);
     }
 
     @Bean
@@ -126,6 +175,11 @@ public class ResilientRedisConfig {
 
     @EventListener(ApplicationReadyEvent.class)
     private void init() {
-        log.info("Running {} version {} with {} replica setting", projectId, projectVersion, resilientRedisProperties.getReplica().getEnabled());
+        log.info("Running {} version {} with replica={}, circuitBreaker={}, retry={}",
+                projectId,
+                projectVersion,
+                resilientRedisProperties.getReplica().getEnabled(),
+                resilientRedisProperties.getCircuitBreakerConfig().isEnabled(),
+                resilientRedisProperties.getRetryConfig().isEnabled());
     }
 }

--- a/src/main/java/io/github/blaspat/ResilientRedisMetrics.java
+++ b/src/main/java/io/github/blaspat/ResilientRedisMetrics.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2024 Blasius Patrick
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.blaspat;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+public class ResilientRedisMetrics {
+
+    private final MeterRegistry registry;
+    private final ConcurrentHashMap<String, Counter> cacheHits = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Counter> cacheMisses = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Counter> errors = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Counter> fallbacks = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Timer> latencies = new ConcurrentHashMap<>();
+
+    public ResilientRedisMetrics(MeterRegistry registry) {
+        this.registry = registry;
+    }
+
+    public void recordHit(String operation) {
+        cacheHits.computeIfAbsent(operation, k ->
+                Counter.builder("redis.cache.hit")
+                        .tag("operation", operation)
+                        .description("Redis cache hit count")
+                        .register(registry))
+                .increment();
+    }
+
+    public void recordMiss(String operation) {
+        cacheMisses.computeIfAbsent(operation, k ->
+                Counter.builder("redis.cache.miss")
+                        .tag("operation", operation)
+                        .description("Redis cache miss count")
+                        .register(registry))
+                .increment();
+    }
+
+    public void recordError(String operation, String errorType) {
+        errors.computeIfAbsent(operation + "_" + errorType, k ->
+                Counter.builder("redis.error")
+                        .tag("operation", operation)
+                        .tag("error", errorType)
+                        .description("Redis error count")
+                        .register(registry))
+                .increment();
+    }
+
+    public void recordFallback(String operation) {
+        fallbacks.computeIfAbsent(operation, k ->
+                Counter.builder("redis.fallback")
+                        .tag("operation", operation)
+                        .description("Redis fallback activation count")
+                        .register(registry))
+                .increment();
+    }
+
+    public void recordLatency(String operation, long durationMs) {
+        latencies.computeIfAbsent(operation, k ->
+                Timer.builder("redis.latency")
+                        .tag("operation", operation)
+                        .description("Redis operation latency")
+                        .register(registry))
+                .record(durationMs, TimeUnit.MILLISECONDS);
+    }
+
+    public <T> T record(String operation, Supplier<T> supplier) {
+        long start = System.currentTimeMillis();
+        try {
+            T result = supplier.get();
+            recordHit(operation);
+            return result;
+        } catch (Exception e) {
+            recordError(operation, e.getClass().getSimpleName());
+            throw e;
+        } finally {
+            recordLatency(operation, System.currentTimeMillis() - start);
+        }
+    }
+
+    public void record(String operation, Runnable runnable) {
+        long start = System.currentTimeMillis();
+        try {
+            runnable.run();
+            recordHit(operation);
+        } catch (Exception e) {
+            recordError(operation, e.getClass().getSimpleName());
+            throw e;
+        } finally {
+            recordLatency(operation, System.currentTimeMillis() - start);
+        }
+    }
+}

--- a/src/main/java/io/github/blaspat/ResilientRedisProperties.java
+++ b/src/main/java/io/github/blaspat/ResilientRedisProperties.java
@@ -33,6 +33,13 @@ public class ResilientRedisProperties extends RedisProperties {
     private Duration connectTimeout;
     private Integer batchSize;
 
+    // Circuit breaker settings
+    private CircuitBreaker circuitBreaker = new CircuitBreaker();
+    // Retry settings
+    private Retry retry = new Retry();
+    // Fallback enabled
+    private boolean fallbackEnabled = false;
+
     @Override
     public Duration getConnectTimeout() {
         if (connectTimeout == null) return Duration.ofSeconds(1L);
@@ -129,5 +136,73 @@ public class ResilientRedisProperties extends RedisProperties {
         public void setPort(Integer port) {
             this.port = port;
         }
+    }
+
+    public static class CircuitBreaker {
+        private boolean enabled = false;
+        private int failureRateThreshold = 50;
+        private int slowCallRateThreshold = 80;
+        private Duration slowCallDurationThreshold = Duration.ofSeconds(2);
+        private Duration waitDurationInOpenState = Duration.ofSeconds(30);
+        private int permittedCallsInHalfOpenState = 5;
+        private int slidingWindowSize = 10;
+        private int minimumCalls = 5;
+
+        public boolean isEnabled() { return enabled; }
+        public void setEnabled(boolean enabled) { this.enabled = enabled; }
+        public int getFailureRateThreshold() { return failureRateThreshold; }
+        public void setFailureRateThreshold(int failureRateThreshold) { this.failureRateThreshold = failureRateThreshold; }
+        public int getSlowCallRateThreshold() { return slowCallRateThreshold; }
+        public void setSlowCallRateThreshold(int slowCallRateThreshold) { this.slowCallRateThreshold = slowCallRateThreshold; }
+        public Duration getSlowCallDurationThreshold() { return slowCallDurationThreshold; }
+        public void setSlowCallDurationThreshold(Duration slowCallDurationThreshold) { this.slowCallDurationThreshold = slowCallDurationThreshold; }
+        public Duration getWaitDurationInOpenState() { return waitDurationInOpenState; }
+        public void setWaitDurationInOpenState(Duration waitDurationInOpenState) { this.waitDurationInOpenState = waitDurationInOpenState; }
+        public int getPermittedCallsInHalfOpenState() { return permittedCallsInHalfOpenState; }
+        public void setPermittedCallsInHalfOpenState(int permittedCallsInHalfOpenState) { this.permittedCallsInHalfOpenState = permittedCallsInHalfOpenState; }
+        public int getSlidingWindowSize() { return slidingWindowSize; }
+        public void setSlidingWindowSize(int slidingWindowSize) { this.slidingWindowSize = slidingWindowSize; }
+        public int getMinimumCalls() { return minimumCalls; }
+        public void setMinimumCalls(int minimumCalls) { this.minimumCalls = minimumCalls; }
+    }
+
+    public static class Retry {
+        private boolean enabled = false;
+        private int maxAttempts = 3;
+        private Duration waitDuration = Duration.ofMillis(200);
+        private Duration maxRetryDuration = Duration.ofSeconds(5);
+
+        public boolean isEnabled() { return enabled; }
+        public void setEnabled(boolean enabled) { this.enabled = enabled; }
+        public int getMaxAttempts() { return maxAttempts; }
+        public void setMaxAttempts(int maxAttempts) { this.maxAttempts = maxAttempts; }
+        public Duration getWaitDuration() { return waitDuration; }
+        public void setWaitDuration(Duration waitDuration) { this.waitDuration = waitDuration; }
+        public Duration getMaxRetryDuration() { return maxRetryDuration; }
+        public void setMaxRetryDuration(Duration maxRetryDuration) { this.maxRetryDuration = maxRetryDuration; }
+    }
+
+    public CircuitBreaker getCircuitBreakerConfig() {
+        return circuitBreaker;
+    }
+
+    public void setCircuitBreakerConfig(CircuitBreaker circuitBreaker) {
+        this.circuitBreaker = circuitBreaker;
+    }
+
+    public Retry getRetryConfig() {
+        return retry;
+    }
+
+    public void setRetryConfig(Retry retry) {
+        this.retry = retry;
+    }
+
+    public boolean isFallbackEnabled() {
+        return fallbackEnabled;
+    }
+
+    public void setFallbackEnabled(boolean fallbackEnabled) {
+        this.fallbackEnabled = fallbackEnabled;
     }
 }

--- a/src/main/java/io/github/blaspat/ResilientRedisTemplate.java
+++ b/src/main/java/io/github/blaspat/ResilientRedisTemplate.java
@@ -20,89 +20,177 @@ import io.lettuce.core.RedisCommandExecutionException;
 import io.lettuce.core.RedisCommandInterruptedException;
 import io.lettuce.core.RedisCommandTimeoutException;
 import io.lettuce.core.RedisConnectionException;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.sync.RedisCommands;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.serializer.SerializationException;
 
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
-public class ResilientRedisTemplate<K, V>{
+public class ResilientRedisTemplate<K, V> {
+
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
     private final RedisTemplate<K, V> redisTemplate;
+    private final CircuitBreakerManager circuitBreakerManager;
+    private final RetryManager retryManager;
+    private final ResilientRedisMetrics metrics;
+    private final boolean circuitBreakerEnabled;
+    private final boolean retryEnabled;
 
     public ResilientRedisTemplate(RedisTemplate<K, V> redisTemplate) {
+        this(redisTemplate, null, null, null);
+    }
+
+    public ResilientRedisTemplate(
+            RedisTemplate<K, V> redisTemplate,
+            CircuitBreakerManager circuitBreakerManager,
+            RetryManager retryManager,
+            ResilientRedisMetrics metrics) {
         this.redisTemplate = redisTemplate;
+        this.circuitBreakerManager = circuitBreakerManager;
+        this.retryManager = retryManager;
+        this.metrics = metrics;
+        this.circuitBreakerEnabled = circuitBreakerManager != null;
+        this.retryEnabled = retryManager != null;
     }
 
     public V get(K key) {
-        try {
-            return redisTemplate.opsForValue().get(key);
-        } catch (SerializationException ex) {
-            logger.warn("Serialization error for key '{}', evicting corrupted cache entry: {}", key, ex.getMessage());
-            this.evict(key);
-            return null;
-        } catch (RedisConnectionException | RedisCommandTimeoutException |
-                 RedisCommandExecutionException | DataAccessException |
-                 RedisCommandInterruptedException e) {
-            logger.error("Redis get error: {}", e.getMessage());
-            return null;
-        }
+        return executeWithResilience("get", () -> {
+            try {
+                V result = redisTemplate.opsForValue().get(key);
+                if (result != null) {
+                    recordHit("get");
+                } else {
+                    recordMiss("get");
+                }
+                return result;
+            } catch (SerializationException ex) {
+                logger.warn("Serialization error for key '{}', evicting corrupted cache entry: {}", key, ex.getMessage());
+                this.evict(key);
+                return null;
+            }
+        });
     }
 
     public void put(K key, V value) {
-        try {
-            redisTemplate.opsForValue().set(key, value);
-        } catch (SerializationException ex) {
-            logger.warn("Serialization error while putting key '{}': {}", key, ex.getMessage());
-        } catch (RedisConnectionException | RedisCommandTimeoutException |
-                 RedisCommandExecutionException | DataAccessException |
-                 RedisCommandInterruptedException e) {
-            logger.error("Redis put error: {}", e.getMessage());
-        }
+        executeWithResilience("put", () -> {
+            try {
+                redisTemplate.opsForValue().set(key, value);
+            } catch (SerializationException ex) {
+                logger.warn("Serialization error while putting key '{}': {}", key, ex.getMessage());
+                throw ex;
+            }
+        });
     }
 
     public void putWithTTL(K key, V value, long timeout, TimeUnit unit) {
-        try {
-            redisTemplate.opsForValue().set(key, value, timeout, unit);
-        } catch (SerializationException ex) {
-            logger.warn("Serialization error while putting key '{}' with TTL: {}", key, ex.getMessage());
-        } catch (RedisConnectionException | RedisCommandTimeoutException |
-                 RedisCommandExecutionException | DataAccessException |
-                 RedisCommandInterruptedException e) {
-            logger.error("Redis putWithTTL error: {}", e.getMessage());
-        }
+        executeWithResilience("putWithTTL", () -> {
+            try {
+                redisTemplate.opsForValue().set(key, value, timeout, unit);
+            } catch (SerializationException ex) {
+                logger.warn("Serialization error while putting key '{}' with TTL: {}", key, ex.getMessage());
+                throw ex;
+            }
+        });
     }
 
     public void evict(K key) {
-        try {
-            redisTemplate.delete(key);
-        } catch (RedisConnectionException | RedisCommandTimeoutException |
-                 RedisCommandExecutionException | DataAccessException |
-                 RedisCommandInterruptedException e) {
-            logger.error("Redis eviction error: {}", e.getMessage());
-        }
+        executeWithResilience("evict", () -> redisTemplate.delete(key));
     }
 
     public void clear() {
-        try {
-            redisTemplate.getConnectionFactory().getConnection().flushDb();
-        } catch (RedisConnectionException | RedisCommandTimeoutException |
-                 RedisCommandExecutionException | DataAccessException |
-                 RedisCommandInterruptedException e) {
-            logger.error("Redis clear error: {}", e.getMessage());
-        }
+        executeWithResilience("clear", () -> {
+            try {
+                redisTemplate.getConnectionFactory().getConnection().flushDb();
+            } catch (RedisConnectionException | RedisCommandTimeoutException |
+                     RedisCommandExecutionException | DataAccessException |
+                     RedisCommandInterruptedException e) {
+                logger.error("Redis clear error: {}", e.getMessage());
+            }
+        });
     }
 
     public void clear(String keyNamePrefix) {
+        executeWithResilience("clearPrefix", () -> {
+            try (Cursor<K> cursor = redisTemplate.scan(ScanOptions.scanOptions()
+                    .match(keyNamePrefix + "*")
+                    .count(100)
+                    .build())) {
+                while (cursor.hasNext()) {
+                    K key = cursor.next();
+                    redisTemplate.delete(key);
+                }
+            } catch (RedisConnectionException | RedisCommandTimeoutException |
+                     RedisCommandExecutionException | DataAccessException |
+                     RedisCommandInterruptedException e) {
+                logger.error("Redis clear(prefix) error: {}", e.getMessage());
+            }
+        });
+    }
+
+    private <T> T executeWithResilience(String operation, Supplier<T> supplier) {
+        Supplier<T> decorated = supplier;
+
+        if (retryEnabled) {
+            decorated = () -> retryManager.execute(supplier);
+        }
+
+        if (circuitBreakerEnabled) {
+            return circuitBreakerManager.execute(decorated::get);
+        }
+
         try {
-            redisTemplate.scan(ScanOptions.scanOptions().match(keyNamePrefix + "*").build()).forEachRemaining(redisTemplate::delete);
+            return decorated.get();
         } catch (RedisConnectionException | RedisCommandTimeoutException |
                  RedisCommandExecutionException | DataAccessException |
                  RedisCommandInterruptedException e) {
-            logger.error("Redis clear error: {}", e.getMessage());
+            logger.error("Redis {} error: {}", operation, e.getMessage());
+            if (metrics != null) {
+                metrics.recordError(operation, e.getClass().getSimpleName());
+            }
+            return null;
+        }
+    }
+
+    private void executeWithResilience(String operation, Runnable runnable) {
+        Runnable decorated = runnable;
+
+        if (retryEnabled) {
+            decorated = () -> retryManager.execute(runnable);
+        }
+
+        if (circuitBreakerEnabled) {
+            circuitBreakerManager.execute(decorated);
+            return;
+        }
+
+        try {
+            decorated.run();
+        } catch (RedisConnectionException | RedisCommandTimeoutException |
+                 RedisCommandExecutionException | DataAccessException |
+                 RedisCommandInterruptedException e) {
+            logger.error("Redis {} error: {}", operation, e.getMessage());
+            if (metrics != null) {
+                metrics.recordError(operation, e.getClass().getSimpleName());
+            }
+        }
+    }
+
+    private void recordHit(String operation) {
+        if (metrics != null) {
+            metrics.recordHit(operation);
+        }
+    }
+
+    private void recordMiss(String operation) {
+        if (metrics != null) {
+            metrics.recordMiss(operation);
         }
     }
 }

--- a/src/main/java/io/github/blaspat/RetryManager.java
+++ b/src/main/java/io/github/blaspat/RetryManager.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 Blasius Patrick
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.blaspat;
+
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryConfig;
+import io.github.resilience4j.retry.RetryRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.function.Supplier;
+
+public class RetryManager {
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final Retry retry;
+
+    public RetryManager(
+            int maxAttempts,
+            Duration waitDuration,
+            Duration maxRetryDuration) {
+
+        RetryConfig config = RetryConfig.custom()
+                .maxAttempts(maxAttempts)
+                .waitDuration(waitDuration)
+                .retryExceptions(Exception.class)
+                .build();
+
+        RetryRegistry registry = RetryRegistry.of(config);
+        this.retry = registry.retry("redis");
+
+        this.retry.getEventPublisher()
+                .onRetry(event ->
+                        logger.warn("Redis retry attempt #{} due to: {}",
+                                event.getNumberOfRetryAttempts(),
+                                event.getLastThrowable().getMessage()));
+    }
+
+    public <T> T execute(Supplier<T> supplier) {
+        return Retry.decorateSupplier(retry, supplier).get();
+    }
+
+    public void execute(Runnable runnable) {
+        Retry.decorateRunnable(retry, runnable).run();
+    }
+
+    public Retry getRetry() {
+        return retry;
+    }
+}


### PR DESCRIPTION
## What Changed

Adds three resilience improvements:

- **Circuit breaker** — Resilience4j CB prevents cascading failures when Redis is down. Trips at configurable failure/slow-call rates.
- **Retry policy** — Automatic retry with configurable max attempts and backoff on transient Redis errors.
- **Micrometer metrics** — Cache hit/miss, errors, latencies, fallback counts via Prometheus.

Also fixes:
- `clear(prefix)` scan cursor resource leak
- `put()` silently swallowing `SerializationException`

## New Dependencies
- `resilience4j-circuitbreaker:2.0.2`
- `resilience4j-retry:2.0.2`
- `micrometer-core:1.10.6`
- `micrometer-registry-prometheus:1.10.6`

All new features are opt-in via `spring.redis.circuit-breaker.*` and `spring.redis.retry.*`.